### PR TITLE
Upgrade analyzer to 6.41.0 to support flutter ^3.22

### DIFF
--- a/secure_dotenv_generator/pubspec.yaml
+++ b/secure_dotenv_generator/pubspec.yaml
@@ -5,10 +5,10 @@ homepage: https://github.com/tomassasovsky/secure_dotenv.dart.git
 repository: https://github.com/tomassasovsky/secure_dotenv.dart.git
 
 environment:
-  sdk: ">=2.17.3 <4.0.0"
+  sdk: ">=3.1.3 <4.0.0"
 
 dependencies:
-  analyzer: ^5.13.0
+  analyzer: ^6.41.0
   build: ^2.4.0
   collection: ^1.17.2
   dotenv: ^4.1.0


### PR DESCRIPTION
## Status

READY

## Description

`intl: 0.19.0` package depends on  `intl_utils: 2.8.7` which depends on `analyzer: ^6.0.0`, since `secure_dotenv_generator` uses `analyzer: 5.13.0` there was a conflict.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
